### PR TITLE
Enable email and phone both not enabled user alerting

### DIFF
--- a/alerter/alerter.go
+++ b/alerter/alerter.go
@@ -115,9 +115,6 @@ func (al *Alerter) work() {
 			users = append(users, univs...)
 			// Send
 			for _, user := range users {
-				if !user.EnableEmail && !user.EnablePhone {
-					continue
-				}
 				d := &msg{
 					Project: proj,
 					Metric:  metric,


### PR DESCRIPTION
This allows us to create bot users without emails or phones.