### PR TITLE
Revert "Use buffered channel on detector recv history metrics channel"

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -306,7 +306,7 @@ func (d *Detector) values(m *models.Metric, fz bool) ([]float64, error) {
 	period := d.cfg.Period
 	// Get values with the same phase.
 	n := 0
-	ch := make(chan metricGetResult, int(expiration/period))
+	ch := make(chan metricGetResult)
 	for stamp := m.Stamp; stamp+expiration > m.Stamp; stamp -= period {
 		start := stamp - offset
 		stop := stamp + offset


### PR DESCRIPTION
Reverts eleme/banshee#444

Performance dose not improve as excepted.