### PR TITLE
fix missing slack url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -240,6 +240,7 @@ func (c *Config) Copy() *Config {
 	cfg.Alerter.DefaultSilentTimeRange = c.Alerter.DefaultSilentTimeRange
 	cfg.Alerter.NotifyAfter = c.Alerter.NotifyAfter
 	cfg.Alerter.AlertCheckInterval = c.Alerter.AlertCheckInterval
+	cfg.Notifier.SlackURL = c.Notifier.SlackURL
 	return cfg
 }
 


### PR DESCRIPTION
the slack URL was missing from config despite being specified in the config file. this commit fixes that problem.