### PR TITLE
fix picking a wrong trending factor bug

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -490,22 +490,16 @@ func (d *Detector) nextIdx(idx *models.Index, m *models.Metric, f float64) *mode
 // pickTrendingFactor picks a trending factor by rules levels.
 func (d *Detector) pickTrendingFactor(rules []*models.Rule) float64 {
 	maxLevel := models.RuleLevelLow
-	factor := d.cfg.Detector.TrendingFactorLowLevel
 	for _, rule := range rules {
-		switch rule.Level {
-		case models.RuleLevelLow:
-			if maxLevel < rule.Level {
-				factor = d.cfg.Detector.TrendingFactorLowLevel
-			}
-		case models.RuleLevelMiddle:
-			if maxLevel < rule.Level {
-				factor = d.cfg.Detector.TrendingFactorMiddleLevel
-			}
-		case models.RuleLevelHigh:
-			if maxLevel < rule.Level {
-				factor = d.cfg.Detector.TrendingFactorHighLevel
-			}
+		if rule.Level > maxLevel {
+			maxLevel = rule.Level
 		}
 	}
-	return factor
+	if maxLevel == models.RuleLevelLow {
+		return d.cfg.Detector.TrendingFactorLowLevel
+	} else if maxLevel == models.RuleLevelMiddle {
+		return d.cfg.Detector.TrendingFactorMiddleLevel
+	} else {
+		return d.cfg.Detector.TrendingFactorHighLevel
+	}
 }

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -39,12 +39,26 @@ func TestFill0Issue470(t *testing.T) {
 func TestPickTrendingFactor(t *testing.T) {
 	cfg := config.New()
 	d := &Detector{cfg: cfg}
+
 	rules := []*models.Rule{
-		&models.Rule{Level: models.RuleLevelLow},
+		{Level: models.RuleLevelLow},
 	}
 	util.Must(t, d.pickTrendingFactor(rules) == cfg.Detector.TrendingFactorLowLevel)
-	rules = append(rules, &models.Rule{Level: models.RuleLevelMiddle})
+
+	rules = []*models.Rule{
+		{Level: models.RuleLevelMiddle},
+	}
 	util.Must(t, d.pickTrendingFactor(rules) == cfg.Detector.TrendingFactorMiddleLevel)
-	rules = append(rules, &models.Rule{Level: models.RuleLevelHigh})
+
+	rules = []*models.Rule{
+		{Level: models.RuleLevelHigh},
+	}
+	util.Must(t, d.pickTrendingFactor(rules) == cfg.Detector.TrendingFactorHighLevel)
+
+	rules = []*models.Rule{
+		{Level: models.RuleLevelLow},
+		{Level: models.RuleLevelHigh},
+		{Level: models.RuleLevelMiddle},
+	}
 	util.Must(t, d.pickTrendingFactor(rules) == cfg.Detector.TrendingFactorHighLevel)
 }


### PR DESCRIPTION
Currently the picked trending factor is not the max factor based rules, but the last rule's factor of rules.
This PR is to pick the correct factor from rules

